### PR TITLE
Correct event name in example for failed submission

### DIFF
--- a/content/reference/forms/embedded-forms/lifecycle.md
+++ b/content/reference/forms/embedded-forms/lifecycle.md
@@ -126,8 +126,8 @@ Event listeners can be registered from [custom JavaScript]({{< ref "/reference/f
       // handle submit-success
     });
 
-    camForm.on('submit-error', function(evt, res) {
-      // handle submit-error:
+    camForm.on('submit-failed', function(evt, res) {
+      // handle submit-failed:
       var error = res[0];
     });
 


### PR DESCRIPTION
There is a small mistake in the example code snippet. The event for failed submissions is `submit-failed` instead of ~submit-error~